### PR TITLE
Fix incorrect typing import in Two Sum solution

### DIFF
--- a/easy/python/two_sum.py
+++ b/easy/python/two_sum.py
@@ -1,10 +1,18 @@
-from ast import List
+"""Two Sum problem solution.
+
+This module contains a simple hash-map based solution to the classic
+Two Sum problem. The original implementation imported ``List`` from the
+``ast`` module which is incorrect; the type resides in ``typing``.
+"""
+
+from typing import List
 
 class Solution:
     def twoSum(self, nums: List[int], target: int) -> List[int]:
-        hash = {}
+        lookup = {}
         for idx, num in enumerate(nums):
-            if num in hash:
-                return [hash[num], idx]
-            else:
-                hash[target - num] = idx
+            if num in lookup:
+                return [lookup[num], idx]
+            lookup[target - num] = idx
+
+        return []


### PR DESCRIPTION
## Summary
- Correct Two Sum Python implementation to use `typing.List` instead of invalid `ast.List`
- Added module docstring and renamed temporary hash to `lookup`, returning empty list when no pair found

## Testing
- `python -m py_compile easy/python/two_sum.py`
- `python - <<'PY'
import sys
sys.path.append('easy/python')
from two_sum import Solution
print(Solution().twoSum([2,7,11,15], 9))
print(Solution().twoSum([3,2,4], 6))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68912bd1086883308084dc743d9d45ed